### PR TITLE
removed more boilerplate

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,8 @@
     // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
     // e.g. "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/explicit-module-boundary-types": "off"
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+
+    "prettier/prettier": ["error", { "endOfLine": "auto" }]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+*\react-app-env.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+.eslintcache
+
 *\react-app-env.d.ts

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "trailingComma": "all",
   "singleQuote": true,
   "printWidth": 100,
-  "tabWidth": 2
+  "tabWidth": 2,
+  "endOfLine": "auto"
 }

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="react-scripts" />


### PR DESCRIPTION
# Summary

> Removed some more boilerplate code and fixes error on Windows machines

## Changelog

- _added_ `react-app-env.d.ts` to `.gitignore`. This is an open issue in the [create-react-app repo](https://github.com/facebook/create-react-app/issues/6560)
- _added_ `.eslintcache` to `.gitignore`. This is a logging file that is generated when lint fails. Was produced when running `yarn start` without the prettier rule added below
- _added_ prettier rule to fix ``Delete `␍`  prettier/prettier`` on Windows machines


## Screenshots
![image](https://user-images.githubusercontent.com/46799304/112192598-7b717b00-8bdd-11eb-8770-eacebe4d0bea.png)
